### PR TITLE
Update tag.lib.php

### DIFF
--- a/src/include/taglib/tag.lib.php
+++ b/src/include/taglib/tag.lib.php
@@ -36,7 +36,7 @@ function lib_tag(&$ctag, &$refObj)
             $ids .= ($ids == '' ? $row['tid'] : ',' . $row['tid']);
         }
         if ($ids != '') {
-            $addsql .= " AND id IN($ids) AND";
+            $addsql .= " AND id IN($ids)";
         }
         if ($addsql == '') return '';
     } else {


### PR DESCRIPTION
解决文章页不能调用当前文章tag的问题，即getall='0'无效。